### PR TITLE
Set heap size in jetty-start script so that auradocs doesn't run out of ...

### DIFF
--- a/bin/jetty-start
+++ b/bin/jetty-start
@@ -1,3 +1,4 @@
 cd `dirname $0`/../aura-jetty
 # if you need to specify a Java system property, do so in aura-jetty/pom.xml, in the <systemProperties> section
-mvn org.mortbay.jetty:jetty-maven-plugin:run -Pdev $@ &
+export MAVEN_OPTS="-Xmx1024m -Xms512m"
+mvn org.mortbay.jetty:jetty-maven-plugin:run $@ &


### PR DESCRIPTION
Fixing OOM error in auradocs on os x.  Also removed reference to nonexistant "dev" maven profile that caused warnings on startup.
