### PR TITLE
CSS cleanup

### DIFF
--- a/aura-components/src/main/components/auradev/showDependencies/showDependencies.css
+++ b/aura-components/src/main/components/auradev/showDependencies/showDependencies.css
@@ -22,13 +22,13 @@
 }
 
 .THIS ol {
-    margin-top : 0px;
+    margin-top : 0;
 }
 
 .THIS .headerline {
     font-weight: bold;
     margin-top : 10px;
-    margin-bottom : 0px;
+    margin-bottom : 0;
 }
 
 .THIS .headerline li {

--- a/aura-components/src/main/components/auradocs/docs/docs.css
+++ b/aura-components/src/main/components/auradocs/docs/docs.css
@@ -40,7 +40,7 @@
 
 .THIS article.content {
 	position: absolute;
-	padding: 0px;
+	padding: 0;
 	top: 70px;
 	right: 0;
 	left: 280px;

--- a/aura-components/src/main/components/aurajstest/jstest/jstest.css
+++ b/aura-components/src/main/components/aurajstest/jstest/jstest.css
@@ -52,13 +52,13 @@
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,StartColorStr='#727a86', EndColorStr='#505864');
     border-bottom: 1px solid #33373d;
     border-right: 1px solid #33373d;
-    -webkit-box-shadow: inset 0px 1px 0px 0px #878e98;
-    -moz-box-shadow: inset 0px 1px 0px 0px #878e98;
-    box-shadow: inset 0px 1px 0px 0px #878e98;
+    -webkit-box-shadow: inset 0 1px 0 0 #878e98;
+    -moz-box-shadow: inset 0 1px 0 0 #878e98;
+    box-shadow: inset 0 1px 0 0 #878e98;
     display: block;
     font-weight: 600;
     color: #fff;
-    text-shadow: 0px 1px 0px rgba(0,0,0,.5);
+    text-shadow: 0 1px 0 rgba(0,0,0,.5);
     margin: 0;
 }
 
@@ -88,9 +88,9 @@
     background-image: linear-gradient(top, rgb(69, 199, 235), rgb(38, 152, 219));
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,StartColorStr='#45c7eb', EndColorStr='#2698db');
     border-bottom: 1px solid #103c56;
-    -webkit-box-shadow: inset 0px 1px 0px 0px #6ad2ef;
-    -moz-box-shadow: inset 0px 1px 0px 0px #6ad2ef;
-    box-shadow: inset 0px 1px 0px 0px #6ad2ef;
+    -webkit-box-shadow: inset 0 1px 0 0 #6ad2ef;
+    -moz-box-shadow: inset 0 1px 0 0 #6ad2ef;
+    box-shadow: inset 0 1px 0 0 #6ad2ef;
 }
 
 .aurajstestJstest ul li.uiTab.active > a.tabHeader {
@@ -172,10 +172,10 @@
     -webkit-border-radius: .769em;
     -moz-border-radius: .769em;
     border-radius: .769em;
-    -webkit-box-shadow: inset 0px 1px 3px 0px rgba(0, 0, 0, .26), 0px 1px 0px 0px rgba(255, 255, 255, .15);
-    -moz-box-shadow: inset 0px 1px 3px 0px rgba(0, 0, 0, .26), 0px 1px 0px 0px rgba(255, 255, 255, .15);
-    box-shadow: inset 0px 1px 3px 0px rgba(0, 0, 0, .26), 0px 1px 0px 0px rgba(255, 255, 255, .15);
-    text-shadow: 0px 1px 0px rgba(0,0,0,.5);
+    -webkit-box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, .26), 0 1px 0 0 rgba(255, 255, 255, .15);
+    -moz-box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, .26), 0 1px 0 0 rgba(255, 255, 255, .15);
+    box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, .26), 0 1px 0 0 rgba(255, 255, 255, .15);
+    text-shadow: 0 1px 0 rgba(0,0,0,.5);
     font-weight: 500;
     background: #2173a1;
 }

--- a/aura-components/src/main/components/ui/autocompleteList/autocompleteList.css
+++ b/aura-components/src/main/components/ui/autocompleteList/autocompleteList.css
@@ -34,6 +34,6 @@
 
 .THIS .listContent ul {
     list-style: none;
-    margin: 0px; 
-    padding: 0px;
+    margin: 0;
+    padding: 0;
 }

--- a/aura-components/src/main/components/ui/carousel/carousel.css
+++ b/aura-components/src/main/components/ui/carousel/carousel.css
@@ -13,53 +13,53 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
- 
+
+
 .THIS   {
  	position: relative;
 	background: #2e4153;
-	display: block;		
+	display: block;
  }
-  
-  
- .THIS .carousel-nav-container { 	
+
+
+ .THIS .carousel-nav-container {
  	position: relative;
  	padding: 21px 0;
 	display: block;
 	width: 100%;
-	text-align: center;	
+	text-align: center;
  }
 
  .THIS .carousel-pages {
  	position: relative;
- 	clear: both;	
+ 	clear: both;
 	overflow: hidden;
-	white-space: nowrap;	 	
+	white-space: nowrap;
  }
-   
- 
- .THIS .carousel-pages .page-list { 
+
+
+ .THIS .carousel-pages .page-list {
  	list-style: none;
- 	padding: 0px;
- 	margin: 0px;
+ 	padding: 0;
+ 	margin: 0;
  }
- 
+
  .THIS .carousel-nav-position-top {
- 	top: 0px;
+ 	top: 0;
  }
-  
+
  .THIS .carousel-nav-position-bottom {
- 	bottom: 0px;
+ 	bottom: 0;
  }
-   
- 
- .THIS .carousel-pages .carousel-page { 	
+
+
+ .THIS .carousel-pages .carousel-page {
  	display: inline-block;
- 	vertical-align: top;    
+ 	vertical-align: top;
  }
- 
+
  .THIS .full-height {
  	height: 100%;
  }
- 
- 
+
+

--- a/aura-components/src/main/components/ui/carouselPageItem/carouselPageItem.css
+++ b/aura-components/src/main/components/ui/carouselPageItem/carouselPageItem.css
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-.THIS   {	
+
+.THIS   {
 	width: 50%;
 	height: 140px;
 	display: table-cell;
@@ -45,6 +45,6 @@
 
 .THIS .entity {
 	border-style: solid;
-	border-width: 0px;
+	border-width: 0;
 	border-radius: 5px;
 }

--- a/aura-components/src/main/components/ui/dataTable/dataTable.css
+++ b/aura-components/src/main/components/ui/dataTable/dataTable.css
@@ -60,4 +60,4 @@
 .uiDataTable th:last-child{border-top-right-radius:3px;}
 .uiDataTable tr:last-child td:first-child{border-bottom-left-radius:3px;}
 .uiDataTable tr:last-child td:last-child{border-bottom-right-radius:3px;}
-.uiDataTable tr:last-child td{border-bottom: 0px;}
+.uiDataTable tr:last-child td{border-bottom: 0;}

--- a/aura-components/src/main/components/ui/menuList/menuList.css
+++ b/aura-components/src/main/components/ui/menuList/menuList.css
@@ -29,6 +29,6 @@ div.THIS.visible {
 
 .THIS ul {
     list-style: none;
-    margin: 0px; 
-    padding: 0px;
+    margin: 0;
+    padding: 0;
 }

--- a/aura-impl/src/test/components/test/testStyleNamespaceTokenValidCSS/testStyleNamespaceTokenValidCSS.css
+++ b/aura-impl/src/test/components/test/testStyleNamespaceTokenValidCSS/testStyleNamespaceTokenValidCSS.css
@@ -94,5 +94,5 @@
 
 
 .THIS ~foo1 +foo2 -foo3 :foo4 #foo5 _foo6 {
-    margin: 0px;
+    margin: 0;
 }

--- a/aura-impl/src/test/components/test/testStyleNamespaceTrueConditions/testStyleNamespaceTrueConditions.css
+++ b/aura-impl/src/test/components/test/testStyleNamespaceTrueConditions/testStyleNamespaceTrueConditions.css
@@ -78,7 +78,7 @@
   	.THIS .stackOrder {
     	z-index: 500;
     }
-} 
+}
 @else {
   	.THIS .stackOrder {
     	z-index: 600;
@@ -94,7 +94,7 @@
     	padding-left: add(15px,
     					  1px);
     }
-} 
+}
 
 @if (WEBKIT) {
 	.THIS h1+h2 {
@@ -104,16 +104,16 @@
 	.THIS h1~p{
 		font-size: 2em;
 	}
-	
+
 	.THIS #content{
 		margin: 0 auto;
 	}
-	
-	.THIS a[href*=".com"] { 
+
+	.THIS a[href*=".com"] {
 		color: blue;
 	}
-	
+
 	.THIS ~foo1 +foo2 -foo3 :foo4 #foo5 _foo6 {
-		margin: 0px;
+		margin: 0;
 	}
 }

--- a/aura-impl/src/test/components/test/testStyleSelectorCaseSensitivity/testStyleSelectorCaseSensitivity.css
+++ b/aura-impl/src/test/components/test/testStyleSelectorCaseSensitivity/testStyleSelectorCaseSensitivity.css
@@ -115,6 +115,6 @@
     color : #1797c0;
     text-align : center;
     float : right;
-    margin : 0px 1px;
+    margin : 0 1px;
 
 }

--- a/aura-impl/src/test/components/test/testValidCSS/testValidCSS.css
+++ b/aura-impl/src/test/components/test/testValidCSS/testValidCSS.css
@@ -25,7 +25,7 @@
     top: 0;
     bottom : 0;
     padding : 0;
-    margin : 0;    
+    margin : 0;
 }
 
 .testTestValidCSS #mask {
@@ -103,7 +103,7 @@
 	position : absolute;
 	z-index : 1;
 	padding : 2px 10px;
-	
+
 }
 
 .testTestValidCSS .toolbar .widget{
@@ -115,14 +115,14 @@
 	color : #1797c0;
 	text-align : center;
 	float : right;
-	margin : 0px 1px;
-	
+	margin : 0 1px;
+
 }
 
 .testTestValidCSS .toolbar.south .widget{
 	background-color : #1797c0;
 	color : white;
-	
+
     -moz-transform: rotate(-30deg);
     -webkit-transform: rotate(-30deg);
 }

--- a/aura-impl/src/test/components/themeTest/invalidMixing/invalidMixing.css
+++ b/aura-impl/src/test/components/themeTest/invalidMixing/invalidMixing.css
@@ -1,3 +1,3 @@
 .THIS {
-  margin: 0px theme('themeTest.baseTheme.margin');
+  margin: 0 theme('themeTest.baseTheme.margin');
 }

--- a/aura-resources/src/main/resources/aura/resources/jiffy/Jiffy.css
+++ b/aura-resources/src/main/resources/aura/resources/jiffy/Jiffy.css
@@ -1,7 +1,7 @@
 .jiffyAbsolute {
     position: absolute;
-    top: 0px;
-    left: 0px;
+    top: 0;
+    left: 0;
     width: 99%;
     cursor: move;
     z-index: 999;
@@ -24,7 +24,7 @@
 
 .jiffyContainer table.measures {
     font-weight: bold;
-    border-width: 0px;
+    border-width: 0;
     border-style: none;
     border-collapse: collapse;
     table-layout: fixed;
@@ -44,7 +44,7 @@
     border-color: #efefef;
     border-style: solid none;
     border-width: 1px 0;
-    padding: 4px 0px;
+    padding: 4px 0;
 }
 
 .jiffyContainer td {
@@ -112,14 +112,14 @@
 .jiffyContainer .bar {
     background-image: url(/img/jiffy/bluegradient.png);
     background-repeat: repeat;
-    background-position: 0px 0px;
+    background-position: 0 0;
     text-align: right;
 }
 
 .jiffyContainer .durationBar {
     background-image: url(/img/jiffy/grayflat.png);
     background-repeat: repeat;
-    background-position: 0px 0px;
+    background-position: 0 0;
 }
 
 .jiffyContainer .elapsed {

--- a/aura/src/test/components/uitest/localizationComponentTest/localizationComponentTest.css
+++ b/aura/src/test/components/uitest/localizationComponentTest/localizationComponentTest.css
@@ -53,7 +53,7 @@
 /* top banner */
 .uitestLocalizationComponentTest.top {
 	width:9%;
-	top: 0px;
+	top: 0;
 	height: 11px;
 }
 


### PR DESCRIPTION
Removes px units from values set to 0 in css files - as they are not needed.
