### PR TITLE
PageObject pattern support

### DIFF
--- a/aura/src/test/java/org/auraframework/test/WebDriverTestCase.java
+++ b/aura/src/test/java/org/auraframework/test/WebDriverTestCase.java
@@ -15,11 +15,27 @@
  */
 package org.auraframework.test;
 
-import java.io.*;
-import java.lang.annotation.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintWriter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.lang.reflect.Method;
-import java.net.*;
-import java.util.*;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -32,25 +48,41 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 import org.auraframework.Aura;
-import org.auraframework.def.*;
+import org.auraframework.def.ApplicationDef;
+import org.auraframework.def.BaseComponentDef;
+import org.auraframework.def.ComponentDef;
+import org.auraframework.def.DefDescriptor;
+import org.auraframework.def.Definition;
 import org.auraframework.system.AuraContext.Mode;
 import org.auraframework.test.WebDriverUtil.BrowserType;
 import org.auraframework.test.annotation.FreshBrowserInstance;
 import org.auraframework.test.annotation.WebDriverTest;
-import org.auraframework.test.page.PageObject;
-import org.auraframework.test.perf.*;
-import org.auraframework.test.perf.metrics.*;
+import org.auraframework.test.perf.PerfResultsUtil;
+import org.auraframework.test.perf.PerfUtil;
+import org.auraframework.test.perf.PerfWebDriverUtil;
+import org.auraframework.test.perf.metrics.PerfMetrics;
+import org.auraframework.test.perf.metrics.PerfMetricsCollector;
+import org.auraframework.test.perf.metrics.PerfRunsCollector;
 import org.auraframework.test.perf.rdp.RDPNotification;
 import org.auraframework.util.AuraUITestingUtil;
 import org.auraframework.util.AuraUtil;
 import org.eclipse.jetty.util.log.Log;
 import org.json.JSONObject;
-import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.interactions.*;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Action;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.HasTouchScreen;
 import org.openqa.selenium.interactions.touch.FlickAction;
 import org.openqa.selenium.interactions.touch.TouchActions;
-import org.openqa.selenium.remote.*;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.ScreenshotException;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -80,7 +112,6 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
     BrowserType currentBrowserType = null;
     protected AuraUITestingUtil auraUITestingUtil;
     protected PerfWebDriverUtil perfWebDriverUtil;
-    private PageObject page;
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.TYPE, ElementType.METHOD })
@@ -104,11 +135,6 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
 
     public WebDriverTestCase(String name) {
         super(name);
-    }
-    
-    public WebDriverTestCase(PageObject page) {
-    	super(page.getName());
-    	this.page = page;
     }
 
     /**
@@ -817,9 +843,6 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
     
     public void setCurrentDriver(WebDriver currentDriver) {
 		this.currentDriver = currentDriver;
-		if (page != null) {
-			page.setDriver(currentDriver);
-		}
     }
 
     /**

--- a/aura/src/test/java/org/auraframework/test/WebDriverTestCase.java
+++ b/aura/src/test/java/org/auraframework/test/WebDriverTestCase.java
@@ -37,6 +37,7 @@ import org.auraframework.system.AuraContext.Mode;
 import org.auraframework.test.WebDriverUtil.BrowserType;
 import org.auraframework.test.annotation.FreshBrowserInstance;
 import org.auraframework.test.annotation.WebDriverTest;
+import org.auraframework.test.page.PageObject;
 import org.auraframework.test.perf.*;
 import org.auraframework.test.perf.metrics.*;
 import org.auraframework.test.perf.rdp.RDPNotification;
@@ -79,6 +80,7 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
     BrowserType currentBrowserType = null;
     protected AuraUITestingUtil auraUITestingUtil;
     protected PerfWebDriverUtil perfWebDriverUtil;
+    private PageObject page;
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.TYPE, ElementType.METHOD })
@@ -103,6 +105,11 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
     public WebDriverTestCase(String name) {
         super(name);
     }
+    
+    public WebDriverTestCase(PageObject page) {
+    	super(page.getName());
+    	this.page = page;
+    }
 
     /**
      * Setup specific to a test case but common for all browsers. Run only once per test case.
@@ -110,7 +117,6 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        
     }
 
     public String getBrowserTypeString() {
@@ -788,7 +794,7 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
             }
 
             logger.info(String.format("Requesting: %s", capabilities));
-            currentDriver = provider.get(capabilities);
+            setCurrentDriver(provider.get(capabilities));
             if (currentDriver == null) {
                 fail("Failed to get webdriver for " + currentBrowserType);
             }
@@ -808,6 +814,13 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
         }
         return currentDriver;
     }
+    
+    public void setCurrentDriver(WebDriver currentDriver) {
+		this.currentDriver = currentDriver;
+		if (page != null) {
+			page.setDriver(currentDriver);
+		}
+    }
 
     /**
      * @return non-null to specify a desired window size to be set when a new driver is created
@@ -823,7 +836,7 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
             } catch (Exception e) {
                 Log.warn(currentDriver.toString(), e);
             }
-            currentDriver = null;
+            setCurrentDriver(null);
         }
     }
 

--- a/aura/src/test/java/org/auraframework/test/WebDriverTestCase.java
+++ b/aura/src/test/java/org/auraframework/test/WebDriverTestCase.java
@@ -841,7 +841,7 @@ public abstract class WebDriverTestCase extends IntegrationTestCase {
         return currentDriver;
     }
     
-    public void setCurrentDriver(WebDriver currentDriver) {
+    protected void setCurrentDriver(WebDriver currentDriver) {
 		this.currentDriver = currentDriver;
     }
 

--- a/aura/src/test/java/org/auraframework/test/page/AuraPageObject.java
+++ b/aura/src/test/java/org/auraframework/test/page/AuraPageObject.java
@@ -1,0 +1,26 @@
+package org.auraframework.test.page;
+
+import org.openqa.selenium.WebDriver;
+
+public abstract class AuraPageObject implements PageObject {
+	
+	private String name;
+	private WebDriver driver;
+	
+	public AuraPageObject(String name) {
+		this.name = name;
+	}
+
+	public void setDriver(WebDriver driver) {
+		this.driver = driver;
+	}
+	
+	protected WebDriver getDriver() {
+		return driver;
+	}
+	
+	public String getName() {
+		return name;
+	}
+
+}

--- a/aura/src/test/java/org/auraframework/test/page/PageObject.java
+++ b/aura/src/test/java/org/auraframework/test/page/PageObject.java
@@ -1,0 +1,11 @@
+package org.auraframework.test.page;
+
+import org.openqa.selenium.WebDriver;
+
+public interface PageObject {
+	
+	String getName();
+
+	void setDriver(WebDriver currentDriver);
+
+}

--- a/aura/src/test/java/org/auraframework/test/page/PageObjectTestCase.java
+++ b/aura/src/test/java/org/auraframework/test/page/PageObjectTestCase.java
@@ -1,14 +1,21 @@
 package org.auraframework.test.page;
 
 import org.auraframework.test.WebDriverTestCase;
+import org.openqa.selenium.WebDriver;
 
 public abstract class PageObjectTestCase<T extends PageObject> extends WebDriverTestCase {
 
-	private T page;
+	private final T page;
 	
 	public PageObjectTestCase(T page) {
-		super(page);
+		super(page.getName());
 		this.page = page;
+	}
+	
+	@Override
+	public void setCurrentDriver(WebDriver currentDriver) {
+		super.setCurrentDriver(currentDriver);
+		page.setDriver(currentDriver);
 	}
 
 	public T page() {

--- a/aura/src/test/java/org/auraframework/test/page/PageObjectTestCase.java
+++ b/aura/src/test/java/org/auraframework/test/page/PageObjectTestCase.java
@@ -1,0 +1,18 @@
+package org.auraframework.test.page;
+
+import org.auraframework.test.WebDriverTestCase;
+
+public abstract class PageObjectTestCase<T extends PageObject> extends WebDriverTestCase {
+
+	private T page;
+	
+	public PageObjectTestCase(T page) {
+		super(page);
+		this.page = page;
+	}
+
+	public T page() {
+		return (T) page;
+	}
+	
+}

--- a/aura/src/test/java/org/auraframework/test/page/PageObjectTestCase.java
+++ b/aura/src/test/java/org/auraframework/test/page/PageObjectTestCase.java
@@ -13,7 +13,7 @@ public abstract class PageObjectTestCase<T extends PageObject> extends WebDriver
 	}
 	
 	@Override
-	public void setCurrentDriver(WebDriver currentDriver) {
+	protected void setCurrentDriver(WebDriver currentDriver) {
 		super.setCurrentDriver(currentDriver);
 		page.setDriver(currentDriver);
 	}


### PR DESCRIPTION
Hi there,

I am a Salesforce new hire and I was doing the Aura101 exercise,
so I start doing some refactoring in the tests to introduce PageObject pattern,
but since that WebDriver instantiation is encapsulated by WebDriverTestCase it becomes quite hard.

I have created some support classes to make it easier and I'll try to show why it's pretty cool.
The two main classes are: PageObjectTestCase and AuraPageObject.

PageObjectTestCase extends WebDriverTestCase, so it keeps all the current behaviour and add strongly typed support for the ObjectPage pattern.

```
public class SampleUITest extends PageObjectTestCase<SamplePageObject> {
    public SampleUITest(String name) {
        super(new SamplePageObject(name));
    }

    public void testExample() throws Exception {
        // page() is exposed by our test support class and is strongly typed
        page().open();
        page().doSomething();
        page().doAnotherAction();

        // asserts
    }
}
```

We can encapsulate all the page logic inside AuraPageObject, and reuse this object in multiples tests.

```
public class SamplePageObject extends AuraPageObject {

    public SamplePageObject(String name) {
        super(name);
    }

    public void open() {
        getDriver().get("myURL"); // getDriver() is injected by WebDriverTestCase automatically
    }

}
```

Those are just some simple test support classes, but in my opinion it helps a lot the introduction of PageObject pattern.

Thanks,
Gabriel Such
