### PR TITLE
Make ariaDropEffect attributes accesslevel to be public

### DIFF
--- a/aura-components/src/main/components/ui/dropzone/dropzone.cmp
+++ b/aura-components/src/main/components/ui/dropzone/dropzone.cmp
@@ -27,7 +27,7 @@
 	<aura:attribute name="dragOverAccessibilityClass" type="String" default="" description="Additional CSS style to be attached to this component while it's being dragged over in accessibility mode. It's defaulted to dragOverClass attribute if it's unspecified."/>
 	
 	<aura:attribute name="label" type="String" description="Label for this component. It's primarily used for accessibility."/>
-	<aura:attribute name="ariaDropEffect" type="String" default="none" access="private" description="Indicate what operation this component is capable of receiving."/>
+	<aura:attribute name="ariaDropEffect" type="String" default="none" access="public" description="Indicate what operation this component is capable of receiving."/>
 	
 	<aura:registerEvent name="dragEnter" type="ui:dragEvent" description="Event fired when a dragged component enters this drop target."/>
 	<aura:registerEvent name="dragOver" type="ui:dragEvent" description="Event fired when a dragged component is hovered over this drop target."/>


### PR DESCRIPTION
The helper methods can be called using a child component that extends this component. In that case we get an attribute access exception. Make it public so that child components can render without access errors.
