### PR TITLE
Whitelist the value attribute for the select element in SecureElement.js

### DIFF
--- a/aura-impl/src/main/resources/aura/locker/SecureElement.js
+++ b/aura-impl/src/main/resources/aura/locker/SecureElement.js
@@ -511,7 +511,7 @@ SecureElement.elementSpecificAttributeWhitelists = {
     "PARAM" : [ "name", "value" ],
     "PROGRESS" : [ "max", "value" ],
     "Q" : [ "cite" ],
-    "SELECT" : [ "autofocus", "disabled", "form", "multiple", "name", "required", "size" ],
+    "SELECT" : [ "autofocus", "disabled", "form", "multiple", "name", "required", "size", "value" ],
     "SOURCE" : [ "src", "type" ],
     "TD" : [ "colSpan", "headers", "rowSpan" ],
     "TEMPLATE" : [ "content" ],


### PR DESCRIPTION
Hi, I'm not sure if this is the right place to commit but this seems like the right file.

Currently I cannot access the value attribute on select elements which seems like a pretty big flaw. THis should fix that.

The current way I get around this is by calling 'find' on the select element and for the function I look for an option element with the selected attribute set to true.
