### PR TITLE
callback in $A.get is optional, and should be marked as such in the jsdoc.

### DIFF
--- a/aura-impl/src/main/resources/aura/Aura.js
+++ b/aura-impl/src/main/resources/aura/Aura.js
@@ -1165,7 +1165,7 @@ AuraInstance.prototype.getToken = function(token){
  * @public
  * @function
  * @param {String} key - The data key to look up on element, for example, <code>$A.get("$Label.section.key")</code>.
- * @param {Function} callback - The method to call with the result if a server trip is expected.
+ * @param {Function} [callback] - The method to call with the result if a server trip is expected.
  * @platform
  */
 AuraInstance.prototype.get = function(key, callback) {


### PR DESCRIPTION
$A.get is used to retrieve labels, and you don't need a callback when you do so. An IDE that has jsdoc support will consider $A.get("$Label.whatever") an invalid function call, as it's missing the optional callback parameter. 