### PR TITLE
Added display:none; to .uiMessage.hide rule

### DIFF
--- a/aura-components/src/main/components/ui/message/message.css
+++ b/aura-components/src/main/components/ui/message/message.css
@@ -30,6 +30,7 @@
 }
 .uiMessage.hide{
     opacity:0;
+	display:none;
 }
 /*******************************************
  this selector needs to be moved into base*/


### PR DESCRIPTION
Added display:none; to .uiMessage.hide rule because element covers the area even after setting opacity:0;