### PR TITLE
Fix: https://github.com/forcedotcom/aura/issues/72

### DIFF
--- a/aura-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/aura-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -57,13 +57,13 @@
     </filter>
 
     <filter-mapping>
-        <url-pattern>*.cmp</url-pattern>
         <filter-name>AuraRewriteFilter</filter-name>
+        <url-pattern>*.cmp</url-pattern>
     </filter-mapping>
 
     <filter-mapping>
-        <url-pattern>*.app</url-pattern>
         <filter-name>AuraRewriteFilter</filter-name>
+        <url-pattern>*.app</url-pattern>
     </filter-mapping>
 
 
@@ -95,8 +95,8 @@
     </filter>
 
     <filter-mapping>
-        <url-pattern>/l/*</url-pattern>
         <filter-name>AuraResourceRewriteFilter</filter-name>
+        <url-pattern>/l/*</url-pattern>
     </filter-mapping>
 
     <servlet>

--- a/aura-archetype/src/main/resources/pom.xml
+++ b/aura-archetype/src/main/resources/pom.xml
@@ -10,6 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <aura.version>${project.version}</aura.version>
+        <jetty.version>9.4.0.v20161208</jetty.version>
     </properties>
 
     <repositories>
@@ -28,32 +30,32 @@
         <dependency>
             <groupId>org.auraframework</groupId>
             <artifactId>aura-util</artifactId>
-            <version>${project.version}</version>
+            <version>${aura.version}</version>
         </dependency>
         <dependency>
             <groupId>org.auraframework</groupId>
             <artifactId>aura</artifactId>
-            <version>${project.version}</version>
+            <version>${aura.version}</version>
         </dependency>
         <dependency>
             <groupId>org.auraframework</groupId>
             <artifactId>aura-impl</artifactId>
-            <version>${project.version}</version>
+            <version>${aura.version}</version>
         </dependency>
         <dependency>
             <groupId>org.auraframework</groupId>
             <artifactId>aura-components</artifactId>
-            <version>${project.version}</version>
+            <version>${aura.version}</version>
         </dependency>
         <dependency>
             <groupId>org.auraframework</groupId>
             <artifactId>aura-impl-expression</artifactId>
-            <version>${project.version}</version>
+            <version>${aura.version}</version>
         </dependency>
         <dependency>
             <groupId>org.auraframework</groupId>
             <artifactId>aura-resources</artifactId>
-            <version>${project.version}</version>
+            <version>${aura.version}</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pjl-comp-filter</groupId>
@@ -82,9 +84,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.mortbay.jetty</groupId>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>8.1.11.v20130520</version>
+                    <version>\${jetty.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -105,7 +107,7 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
                     <stopKey>simple</stopKey>
@@ -160,7 +162,7 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.mortbay.jetty</groupId>
+                        <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
                         <executions>
                             <execution>


### PR DESCRIPTION
Fix java.lang.ArrayIndexOutOfBoundsException: 29146
    at org.objectweb.asm.ClassReader.<init>(Unknown Source)

This appears to be due to using Jetty 8.x which includes a version of asm that
can't handle Java8 bytecode.

1.) Upgrade Jetty from org.mortbay.jetty:8.1.15.v20140411
to org.eclipse.jetty:9.4.0.v20161208
2.) Minor fixes to web.xml to conform to it's schema
3.) parameterize aura-version so it's configures via property