### PR TITLE
https://github.com/forcedotcom/aura/issues/81

### DIFF
--- a/aura-integration-test/src/test/java/org/auraframework/integration/test/configuration/JettyTestServletConfig.java
+++ b/aura-integration-test/src/test/java/org/auraframework/integration/test/configuration/JettyTestServletConfig.java
@@ -29,6 +29,7 @@ import org.auraframework.test.util.SauceUtil;
 import org.auraframework.util.test.configuration.TestServletConfig;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 
 import javax.inject.Inject;
 import java.net.InetAddress;
@@ -58,8 +59,8 @@ public class JettyTestServletConfig implements TestServletConfig {
         if (spawnJetty) {
             Server server = AuraJettyServer.getInstance();
             Connector connector = server.getConnectors()[0];
-            port = connector.getPort();
-            host = connector.getHost();
+            port = ((ServerConnector)connector).getPort();
+            host = ((ServerConnector)connector).getHost();
             if (host == null) {
                 try {
                     host = getHost();

--- a/aura-integration-test/src/test/java/org/auraframework/integration/test/util/AuraJettyServer.java
+++ b/aura-integration-test/src/test/java/org/auraframework/integration/test/util/AuraJettyServer.java
@@ -16,12 +16,11 @@
 package org.auraframework.integration.test.util;
 
 import java.io.File;
+import java.net.InetSocketAddress;
 
 import org.auraframework.Aura;
 import org.auraframework.util.IOUtil;
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.openqa.selenium.net.PortProber;
 
@@ -50,14 +49,8 @@ public class AuraJettyServer extends Server {
     }
 
     private AuraJettyServer(String host, int port, String contextPath) {
+    	super(new InetSocketAddress(host!=null?host:"localhost", port));
         File tmpDir = new File(IOUtil.newTempDir("webcache"));
-
-        Connector connector = new SelectChannelConnector();
-        if (host != null) {
-            connector.setHost(host);
-        }
-        connector.setPort(port);
-        setConnectors(new Connector[] { connector });
 
         WebAppContext context = new WebAppContext();
             context.setDefaultsDescriptor(Aura.class.getResource("/aura/webapp/WEB-INF/webdefault.xml").toString());

--- a/aura-jetty/pom.xml
+++ b/aura-jetty/pom.xml
@@ -120,7 +120,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
                     <connectors>
@@ -217,7 +217,7 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.mortbay.jetty</groupId>
+						<groupId>org.eclipse.jetty</groupId>
 						<artifactId>jetty-maven-plugin</artifactId>
 						<configuration>
 							<systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <xunit.js.isStrict>true</xunit.js.isStrict>
         <xunit.js.currentModule>${project.basedir}</xunit.js.currentModule>
         <spring.version>4.1.7.RELEASE</spring.version>
-        <jetty.version>8.1.15.v20140411</jetty.version>
+        <jetty.version>9.4.0.v20161208</jetty.version>
         <node.download.root.url>http://repo.auraframework.org/simple/plugins-release-local/node/</node.download.root.url>
         <npm.download.root.url>http://repo.auraframework.org/simple/plugins-release-local/npm/</npm.download.root.url>
         <node.version>v4.2.1</node.version>
@@ -711,7 +711,7 @@
                     <version>1.8</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.mortbay.jetty</groupId>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                     <dependencies>


### PR DESCRIPTION
Replace end-of-life Jetty-8 with Jetty-9.

As of 2017-01-24, Aura is using Jetty-8, which is "end-of-life"
and only appropriate for Java-6, however Aura is on Java-8.

See: 
https://en.wikipedia.org/wiki/Jetty_(web_server)#History
https://github.com/forcedotcom/aura/issues/81