### PR TITLE
Add dataset support to secure script

### DIFF
--- a/aura-components/src/test/components/lockerTest/secureScriptTest/secureScriptTest.cmp
+++ b/aura-components/src/test/components/lockerTest/secureScriptTest/secureScriptTest.cmp
@@ -21,6 +21,7 @@
     <aura:method name="testScriptSrcExposed"/>
     <aura:method name="testGetSetAttribute"/>
     <aura:method name="testGetSetAttributeNode"/>
+    <aura:method name="testGetSetDataset">
     <aura:method name="testScriptsFromUnsafeSourceBlocked"/>
     <div aura:id="title">SecureScriptElement test</div>
 

--- a/aura-components/src/test/components/lockerTest/secureScriptTest/secureScriptTestController.js
+++ b/aura-components/src/test/components/lockerTest/secureScriptTest/secureScriptTestController.js
@@ -29,6 +29,42 @@
         testUtils.assertEquals(null, script.getAttribute("data-foo"), "Unexpected attribute value, should be undefined");
     },
 
+    testGetSetDataset: function(cmp, event, helper) {
+        var testUtils = cmp.get("v.testUtils");
+
+        // Create the script.
+        var script = document.createElement("script");
+
+        // Empty test.
+        testUtils.assertEquals("DOMStringMap", typeof(script.dataset), "Empty dataset has unexpected type.");
+        testUtils.assertEquals(0, Object.keys(test.dataset).length, "Empty dataset has unexpected length.");
+
+        // Set the foo using the dataset.
+        script.dataset.foo = "bar";
+
+        // Check if we have a DOMStringMap with 1 property that is "foo" with the value bar;
+        testUtils.assertEquals("DOMStringMap", typeof(script.dataset), "Dataset has unexpected type.");
+        testUtils.assertEquals(1, Object.keys(test.dataset).length, "Dataset has unexpected length.");
+        testUtils.assertEquals("bar", script.dataset.foo , "Unexpected dataset value, should be bar.");
+
+        // Check if the get attribute  works.
+        testUtils.assertEquals("bar", script.getAttribute("data-foo"), "Unexpected attribute value, should be bar.");
+
+        // Check if we can set the dataset using the set attribute.
+        script.setAttribute("data-foo", "bar2");
+
+        testUtils.assertEquals(1, Object.keys(test.dataset).length, "Dataset has unexpected length, should be 1.");
+        testUtils.assertEquals(null, script.dataset.foo , "Unexpected dataset value, should be bar2.");
+
+        var script = document.createElement("script");
+        // Make sure 2 attribute works.
+        script.dataset.foo = "bar";
+        script.dataset.bar = "foo";
+        testUtils.assertEquals(2, Object.keys(test.dataset).length, "Dataset has unexpected length, should be 2.");
+        testUtils.assertEquals("bar", script.getAttribute("data-foo"), "Unexpected attribute value for foo, should be bar.");
+        testUtils.assertEquals("foo", script.getAttribute("data-bar"), "Unexpected attribute value for bar, should be foo.");
+    },
+
     testGetSetAttributeNode: function(cmp) {
         var testUtils = cmp.get("v.testUtils");
 

--- a/aura-components/src/test/components/lockerTest/secureScriptTest/secureScriptTestTest.js
+++ b/aura-components/src/test/components/lockerTest/secureScriptTest/secureScriptTestTest.js
@@ -24,6 +24,12 @@
         }
     },
 
+    testGetSetDataset: {
+        test: function(cmp) {
+            cmp.testGetSetDataset();
+        }
+    },
+
     testGetSetAttributeNode: {
         test: function(cmp) {
             cmp.testGetSetAttributeNode();

--- a/aura-impl/src/main/resources/aura/locker/SecureScriptElement.js
+++ b/aura-impl/src/main/resources/aura/locker/SecureScriptElement.js
@@ -63,6 +63,16 @@ function SecureScriptElement(el, key) {
 			}
 		},
 
+		// dataset can only change `data-` attributes, thus, it safe to expose.
+		dataset : {
+			get: function () {
+				return o.dataset;
+			},
+			set: function (value) {
+				o.dataset = value;
+			}
+		},
+
 		getAttributeNode : {
 			value: function(name) {
 				return el.getAttributeNode(getAttributeName(name));

--- a/aura-impl/src/main/resources/aura/locker/SecureScriptElement.js
+++ b/aura-impl/src/main/resources/aura/locker/SecureScriptElement.js
@@ -63,7 +63,7 @@ function SecureScriptElement(el, key) {
 			}
 		},
 
-		// dataset can only change `data-` attributes, thus, it safe to expose.
+		// dataset can only change `data-` attributes, thus, it is safe to expose.
 		dataset : {
 			get: function () {
 				return o.dataset;


### PR DESCRIPTION
I have added the dataset property to the LockerService SecureScriptElement. There is no workaround right now to access the attributes names on a `script` tag when LockerService is enabled. This is related to my [question on StackExchange](http://salesforce.stackexchange.com/questions/162063/lockerservice-dataset-property-on-script-tags-doesnt-work). 

I haven't found a way to execute the aura component tests, but I've written them.

I've also check the [`dataset` documentation](https://developer.mozilla.org/en/docs/Web/API/HTMLElement/dataset), the property can only affect `data-` attributes, thus, it cannot change the `src` attribute for malicious code injections.

It could, on the other hand, change the `data-locker-src`, but if the code is able to access the `dataset` property, it can also use the `src` property. So no additional harm there either.

