### PR TITLE
Add error handling for Secure Script Element

### DIFF
--- a/aura-impl/src/main/resources/aura/locker/SecureScriptElement.js
+++ b/aura-impl/src/main/resources/aura/locker/SecureScriptElement.js
@@ -124,9 +124,9 @@ SecureScriptElement.run = function(st) {
             $A.lockerService.create(xhr.responseText, key, src, true);
 
             el.dispatchEvent(new Event("load"));
+        } else if (xhr.status >= 400 && xhr.status < 600) {
+            el.dispatchEvent(new Event("error"));
         }
-
-        // DCHASMAN TODO W-2837800 Add in error handling for 404's etc
     };
 
     xhr.open("GET", src, true);


### PR DESCRIPTION
This addresses Issue #96. It gives client code an opportunity to respond to 404 and other errors that prevent the script from loading.