### PR TITLE
data-aura-rendered-by incorrectly written as '[object Window]'

### DIFF
--- a/aura-impl/src/main/resources/aura/component/HtmlComponent.js
+++ b/aura-impl/src/main/resources/aura/component/HtmlComponent.js
@@ -245,7 +245,7 @@ HtmlComponent.prototype["renderer"] = {
             helper.createHtmlAttribute(component, element, attribute, HTMLAttributes[attribute]);
         }
         
-        $A.util.setDataAttribute(element, $A.componentService.renderedBy, this.globalId);
+        $A.util.setDataAttribute(element, $A.componentService.renderedBy, component.globalId);
 
         helper.processJavascriptHref(element);
 


### PR DESCRIPTION
In `Component.prototype.render`, we [grab](https://github.com/forcedotcom/aura/blob/463b7dc4844da49e7a484446025be092066651d5/aura-impl/src/main/resources/aura/component/Component.js#L1916) a reference to `this["renderer"]["render”]`, and then [call](https://github.com/forcedotcom/aura/blob/463b7dc4844da49e7a484446025be092066651d5/aura-impl/src/main/resources/aura/component/Component.js#L1921) that method from the reference. `this` inside the `render` method will now be the window, instead of the `Component` instance.

[This](http://jsbin.com/kusiniduya/edit?js,console) jsbin simplifies the issue.

![image](https://user-images.githubusercontent.com/9857665/34223004-499fe458-e583-11e7-8ac5-707962445567.png)
