### PR TITLE
docs: horizontal scrolling workaround

### DIFF
--- a/aura-components/src/main/components/ui/scrollerWrapper/scrollerWrapper.auradoc
+++ b/aura-components/src/main/components/ui/scrollerWrapper/scrollerWrapper.auradoc
@@ -17,7 +17,7 @@
 -->
 <aura:documentation> 
     <aura:description>
-        <p>A <code>ui:scrollerWrapper</code> creates a container that enables native scrolling in the Salesforce app. This component enables you to nest more than one scroller inside the container.
+        <p><code>ui:scrollerWrapper</code> creates a container that enables native scrolling in the Salesforce app. This component enables you to nest more than one scroller inside the container.
         Use the <code>class</code> attribute to define the height and width of the container. To enable scrolling, specify a height that's smaller than its content.</p>
         <p>This example creates a scrollable area with a height of 300px.</p>
         <pre>&lt;aura:component>
@@ -31,7 +31,7 @@
     height: 300px;
 }
         </pre>
-        <p>The Lightning Design System <code>scrollable</code> class isn't compatible with native scrolling on mobile devices. Use <code>ui:scrollerWrapper</code> if you want to enable scrolling in Salesforce1.</p>
+        <p>The Lightning Design System <code>scrollable</code> class isn't compatible with native scrolling on mobile devices. Use <code>ui:scrollerWrapper</code> if you want to enable scrolling in the Salesforce app.</p>
           
         <h4>Usage Considerations</h4>
         <p>In Google Chrome on mobile devices, nested <code>ui:scrollerWrapper</code> components are not scrollable when <code>border-radius</code> CSS property is set to a non-zero value.
@@ -56,14 +56,16 @@
     /* make innerScroller rounded */
     border-radius: 10px;
 }</pre>
-        <h4>Methods</h4>
-        <p>This component supports the following method.</p>
-        <p><code>scrollTo(destination, xcoord, ycoord)</code>: Scrolls the content to a specified location.</p>
-        <ul>
-            <li><code>destination</code> (String): The target location. Valid values: custom, top, bottom, left, and right. For custom destination, xcoord and ycoord are used to determine the target location.</li>
-            <li><code>xcoord</code> (Integer): X coordinate for custom destination. The default is 0.</li>
-            <li><code>ycoord</code> (Integer): Y coordinate for custom destination. The default is 0.</li>
-        </ul>
+        <p><code>ui:scrollerWrapper</code> does not support horizontal scrolling. 
+        You can prevent <code>ui:scrollerWrapper</code> from stopping the default action on the <code>touchmove</code> event on mobile devices.</p>
+        <pre>&lt;div ontouchmove="{!c.cancelTouchMove}" 
+        style="width: 100%, height: 100%; overflow: auto;"> 
+            &lt;!-- Scrollable content here -->
+&lt;/div></pre>
+        <p>Stop propagation of the event in your client-side controller.</p>
+        <pre>cancelTouchMove: function(cmp, event, helper) {
+    event.stopPropagation();
+}</pre>
     </aura:description>
 </aura:documentation> 
 


### PR DESCRIPTION
Also removing the **Methods** section since the Specification tab now displays methods.
@bug W-5876559@